### PR TITLE
Fix file_output_stream, add read_all_text_alloc

### DIFF
--- a/src/babel-serializer/file.cc
+++ b/src/babel-serializer/file.cc
@@ -1,10 +1,11 @@
 #include "file.hh"
 
+#include <fstream>
+
 #include <clean-core/array.hh>
 #include <clean-core/format.hh>
+#include <clean-core/macros.hh>
 #include <clean-core/string.hh>
-
-#include <fstream>
 
 void babel::file::read(cc::stream_ref<std::byte> out, cc::string_view filename, error_handler on_error)
 {
@@ -103,4 +104,15 @@ bool babel::file::exists(cc::string_view filename)
     return std::ifstream(cc::string(filename).c_str()).good();
 }
 
-babel::file::file_output_stream::file_output_stream(cc::string_view filename) { fopen(cc::string(filename).c_str(), "wb"); }
+babel::file::file_output_stream::file_output_stream(const char* filename)
+{
+#ifdef CC_OS_WINDOWS
+    errno_t err = ::fopen_s(&_file, filename, "wb");
+    if (err != 0)
+        _file = nullptr;
+#else
+    _file = std::fopen(filename, "wb");
+#endif
+}
+
+babel::file::file_output_stream::file_output_stream(cc::string_view filename) : file_output_stream(cc::string(filename).c_str()) {}

--- a/src/babel-serializer/file.hh
+++ b/src/babel-serializer/file.hh
@@ -17,15 +17,17 @@ bool exists(cc::string_view filename);
 /// reads a file and writes all bytes in the provided stream (buffered)
 void read(cc::stream_ref<std::byte> out, cc::string_view filename, error_handler on_error = default_error_handler);
 
-/// reads a file and returns the content as a string
+/// reads a file and returns the content as a string (null terminated)
 cc::string read_all_text(cc::string_view filename, error_handler on_error = default_error_handler);
+cc::alloc_array<char> read_all_text(char const* filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
+cc::alloc_array<char> read_all_text(cc::string_view filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
 
 /// reads a file and returns the content as an array of bytes
 cc::array<std::byte> read_all_bytes(cc::string_view filename, error_handler on_error = default_error_handler);
+cc::alloc_array<std::byte> read_all_bytes(char const* filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
+cc::alloc_array<std::byte> read_all_bytes(cc::string_view filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
 
 /// reads a file and returns the content as an allocator-backed array of chars (null terminated)
-cc::alloc_array<char> read_all_text_alloc(char const* filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
-cc::alloc_array<char> read_all_text_alloc(cc::string_view filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
 
 /// writes the given binary data to a file
 void write(cc::string_view filename, cc::span<std::byte const> data, error_handler on_error = default_error_handler);

--- a/src/babel-serializer/file.hh
+++ b/src/babel-serializer/file.hh
@@ -35,14 +35,24 @@ void write_lines(cc::string_view filename, cc::range_ref<cc::string_view> lines,
 /// NOTE: overwrites existing files
 struct file_output_stream
 {
+    file_output_stream(char const* filename);
     file_output_stream(cc::string_view filename);
-    ~file_output_stream() { fclose(file); }
 
-    void operator()(cc::string_view content) { fwrite(content.data(), 1, content.size(), file); }
-    void operator()(cc::span<char const> content) { fwrite(content.data(), 1, content.size(), file); }
-    void operator()(cc::span<std::byte const> content) { fwrite(content.data(), 1, content.size(), file); }
+    ~file_output_stream()
+    {
+        if (_file)
+        {
+            std::fclose(_file);
+        }
+    }
+
+    void operator()(cc::string_view content) { fwrite(content.data(), 1, content.size(), _file); }
+    void operator()(cc::span<char const> content) { fwrite(content.data(), 1, content.size(), _file); }
+    void operator()(cc::span<std::byte const> content) { fwrite(content.data(), 1, content.size(), _file); }
+
+    bool valid() const { return _file != nullptr; }
 
 private:
-    FILE* file = nullptr;
+    FILE* _file = nullptr;
 };
 }

--- a/src/babel-serializer/file.hh
+++ b/src/babel-serializer/file.hh
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 
+#include <clean-core/alloc_array.hh>
 #include <clean-core/range_ref.hh>
 #include <clean-core/stream_ref.hh>
 #include <clean-core/string_view.hh>
@@ -13,14 +14,18 @@ namespace babel::file
 /// returns true if the file exists and can be read
 bool exists(cc::string_view filename);
 
-/// reads a file writes all bytes in the provided stream
+/// reads a file and writes all bytes in the provided stream (buffered)
 void read(cc::stream_ref<std::byte> out, cc::string_view filename, error_handler on_error = default_error_handler);
 
-/// reads a file and returns the content as string
+/// reads a file and returns the content as a string
 cc::string read_all_text(cc::string_view filename, error_handler on_error = default_error_handler);
 
-/// reads a file and returns the content as array of bytes
+/// reads a file and returns the content as an array of bytes
 cc::array<std::byte> read_all_bytes(cc::string_view filename, error_handler on_error = default_error_handler);
+
+/// reads a file and returns the content as an allocator-backed array of chars (null terminated)
+cc::alloc_array<char> read_all_text_alloc(char const* filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
+cc::alloc_array<char> read_all_text_alloc(cc::string_view filename, cc::allocator* alloc, error_handler on_error = default_error_handler);
 
 /// writes the given binary data to a file
 void write(cc::string_view filename, cc::span<std::byte const> data, error_handler on_error = default_error_handler);


### PR DESCRIPTION
- fix file_output_stream
    - fix ctor not assigning member
    - fix win32 CRT deprecation warning
    - add cstring overload without heap alloc
    - add `bool valid()`
- add read_all_text_alloc